### PR TITLE
refactor(viewmodel): Introduce ViewState for robust state management

### DIFF
--- a/lib/features/presentation/pages/product_page.dart
+++ b/lib/features/presentation/pages/product_page.dart
@@ -51,37 +51,50 @@ class _ProductPageState extends State<ProductPage> {
           Expanded(
             child: Consumer<ProductViewModel>(
               builder: (context, viewModel, child) {
-                if (viewModel.isLoading) {
-                  return const Center(child: CircularProgressIndicator());
-                }
-
-                if (viewModel.products.isEmpty) {
-                  return const Center(child: Text('No products found.'));
-                }
-
-                return ListView.builder(
-                  itemCount: viewModel.products.length,
-                  itemBuilder: (context, index) {
-                    final product = viewModel.products[index];
-                    return ListTile(
-                      title: Text(product.name),
-                      subtitle: Text('\$${product.price.toStringAsFixed(2)}'),
-                      trailing: Row(
-                        mainAxisSize: MainAxisSize.min,
-                        children: [
-                          IconButton(
-                            icon: const Icon(Icons.edit),
-                            onPressed: () => _showProductDialog(product: product),
-                          ),
-                          IconButton(
-                            icon: const Icon(Icons.delete),
-                            onPressed: () => _showDeleteConfirmation(product.id),
-                          ),
-                        ],
+                switch (viewModel.state) {
+                  case ViewState.loading:
+                    return const Center(child: CircularProgressIndicator());
+                  case ViewState.error:
+                    return Center(
+                      child: Padding(
+                        padding: const EdgeInsets.all(16.0),
+                        child: Text(
+                          'An error occurred: ${viewModel.errorMessage}',
+                          textAlign: TextAlign.center,
+                        ),
                       ),
                     );
-                  },
-                );
+                  case ViewState.loaded:
+                    if (viewModel.products.isEmpty) {
+                      return const Center(child: Text('No products found.'));
+                    }
+                    return ListView.builder(
+                      itemCount: viewModel.products.length,
+                      itemBuilder: (context, index) {
+                        final product = viewModel.products[index];
+                        return ListTile(
+                          title: Text(product.name),
+                          subtitle:
+                              Text('\$${product.price.toStringAsFixed(2)}'),
+                          trailing: Row(
+                            mainAxisSize: MainAxisSize.min,
+                            children: [
+                              IconButton(
+                                icon: const Icon(Icons.edit),
+                                onPressed: () =>
+                                    _showProductDialog(product: product),
+                              ),
+                              IconButton(
+                                icon: const Icon(Icons.delete),
+                                onPressed: () =>
+                                    _showDeleteConfirmation(product.id),
+                              ),
+                            ],
+                          ),
+                        );
+                      },
+                    );
+                }
               },
             ),
           ),

--- a/lib/features/presentation/viewmodels/product_view_model.dart
+++ b/lib/features/presentation/viewmodels/product_view_model.dart
@@ -3,28 +3,35 @@ import 'package:flutter/material.dart';
 import 'package:prueba_experis/features/data/models/product_model.dart';
 import '../../data/repositories/product_repository.dart';
 
+enum ViewState { loading, loaded, error }
+
 class ProductViewModel extends ChangeNotifier {
   final ProductRepository _productRepository = ProductRepository();
 
   List<ProductModel> _products = [];
   List<ProductModel> get products => _products;
 
-  bool _isLoading = false;
-  bool get isLoading => _isLoading;
+  ViewState _state = ViewState.loading;
+  ViewState get state => _state;
 
-  void _setLoading(bool value) {
-    _isLoading = value;
+  String _errorMessage = '';
+  String get errorMessage => _errorMessage;
+
+  void _setState(ViewState newState) {
+    _state = newState;
     notifyListeners();
   }
 
   Future<void> fetchProducts() async {
-    _setLoading(true);
+    _setState(ViewState.loading);
     try {
       _products = await _productRepository.getAllProducts();
+      _setState(ViewState.loaded);
     } catch (e) {
-      // Handle error
-    } finally {
-      _setLoading(false);
+      _errorMessage = e.toString();
+      // ignore: avoid_print
+      print('Error fetching products: $_errorMessage');
+      _setState(ViewState.error);
     }
   }
 
@@ -33,7 +40,10 @@ class ProductViewModel extends ChangeNotifier {
       await _productRepository.addProduct(product);
       await fetchProducts(); // Refresh the list
     } catch (e) {
-      // Handle error
+      _errorMessage = e.toString();
+      // ignore: avoid_print
+      print('Error adding product: $_errorMessage');
+      _setState(ViewState.error);
     }
   }
 
@@ -42,7 +52,10 @@ class ProductViewModel extends ChangeNotifier {
       await _productRepository.updateProduct(product);
       await fetchProducts(); // Refresh the list
     } catch (e) {
-      // Handle error
+      _errorMessage = e.toString();
+      // ignore: avoid_print
+      print('Error updating product: $_errorMessage');
+      _setState(ViewState.error);
     }
   }
 
@@ -51,22 +64,27 @@ class ProductViewModel extends ChangeNotifier {
       await _productRepository.deleteProduct(productId);
       await fetchProducts(); // Refresh the list
     } catch (e) {
-      // Handle error
+      _errorMessage = e.toString();
+      // ignore: avoid_print
+      print('Error deleting product: $_errorMessage');
+      _setState(ViewState.error);
     }
   }
 
   Future<void> searchProducts(String query) async {
-    _setLoading(true);
+    _setState(ViewState.loading);
     try {
       if (query.isEmpty) {
         _products = await _productRepository.getAllProducts();
       } else {
         _products = await _productRepository.searchProducts(query);
       }
+      _setState(ViewState.loaded);
     } catch (e) {
-      // Handle error
-    } finally {
-      _setLoading(false);
+      _errorMessage = e.toString();
+      // ignore: avoid_print
+      print('Error searching products: $_errorMessage');
+      _setState(ViewState.error);
     }
   }
 }


### PR DESCRIPTION
Replaced the boolean `isLoading` flag in `ProductViewModel` with a `ViewState` enum (`loading`, `loaded`, `error`).

This addresses the user's request to adopt a state management pattern similar to their example.

Enhanced error handling in all ViewModel methods by catching exceptions, storing the error message, and transitioning to an `error` state. This fixes the core issue where CRUD operations were failing silently due to suppressed errors.

Updated `ProductPage` to react to the new `ViewState`, displaying a loading indicator, the product list, or a descriptive error message on the UI.